### PR TITLE
Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,11 @@
-podTemplate(label: 'buildPod', containers: [
+podTemplate(label: 'buildHmdaHelp', containers: [
   containerTemplate(name: 'docker', image: 'docker', ttyEnabled: true, command: 'cat'),
   containerTemplate(name: 'helm', image: 'lachlanevenson/k8s-helm', ttyEnabled: true, command: 'cat')
 ],
 volumes: [
   hostPathVolume(mountPath: '/var/run/docker.sock', hostPath: '/var/run/docker.sock'),
 ]) {
-   node('buildPod') {
+   node('buildHmdaHelp') {
      def repo = checkout scm
      def gitCommit = repo.GIT_COMMIT
      def gitBranch = repo.GIT_BRANCH

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ volumes: [
 
     stage('Deploy') {
       container('helm') {
-        sh "helm upgrade --install --force --namespace=default --values=hmda-help/kubernetes/values.yaml --set image.tag=${gitBranch} hmda-help-${gitBranch} kubernetes/hmda-help"
+        sh "helm upgrade --install --force --namespace=default --values=kubernetes/values.yaml --set image.tag=${gitBranch} hmda-help-${gitBranch} kubernetes/hmda-help"
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,8 +24,11 @@ volumes: [
       }
 
     stage('Deploy') {
+      when {
+        expression { return gitBranch == 'master' }
+      }
       container('helm') {
-        sh "helm upgrade --install --force --namespace=default --values=kubernetes/hmda-help/values.yaml --set image.tag=${gitBranch} hmda-help-${gitBranch} kubernetes/hmda-help"
+        sh "helm upgrade --install --force --namespace=default --values=kubernetes/hmda-help/values.yaml --set image.tag=${gitBranch} hmda-help kubernetes/hmda-help"
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ volumes: [
 
     stage('Deploy') {
       container('helm') {
-        sh "helm upgrade --install --force --namespace=default --values=kubernetes/values.yaml --set image.tag=${gitBranch} hmda-help-${gitBranch} kubernetes/hmda-help"
+        sh "helm upgrade --install --force --namespace=default --values=kubernetes/hmda-help/values.yaml --set image.tag=${gitBranch} hmda-help-${gitBranch} kubernetes/hmda-help"
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,34 @@
+podTemplate(label: 'buildPod', containers: [
+  containerTemplate(name: 'docker', image: 'docker', ttyEnabled: true, command: 'cat'),
+  containerTemplate(name: 'helm', image: 'lachlanevenson/k8s-helm', ttyEnabled: true, command: 'cat')
+],
+volumes: [
+  hostPathVolume(mountPath: '/var/run/docker.sock', hostPath: '/var/run/docker.sock'),
+]) {
+   node('buildPod') {
+     def repo = checkout scm
+     def gitCommit = repo.GIT_COMMIT
+     def gitBranch = repo.GIT_BRANCH
+     def shortGitCommit = "${gitCommit[0..10]}"
+
+    stage('Build And Publish Docker Image') {
+      container('docker') {
+        withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'dockerhub',
+            usernameVariable: 'DOCKER_HUB_USER', passwordVariable: 'DOCKER_HUB_PASSWORD']]) {
+              sh "docker build --rm -t=${env.DOCKER_HUB_USER}/hmda-help ."
+              sh "docker tag ${env.DOCKER_HUB_USER}/hmda-help ${env.DOCKER_HUB_USER}/hmda-help:${gitBranch}"
+              sh "docker login -u ${env.DOCKER_HUB_USER} -p ${env.DOCKER_HUB_PASSWORD} "
+              sh "docker push ${env.DOCKER_HUB_USER}/hmda-help:${gitBranch}"
+            }
+        }
+      }
+
+    stage('Deploy') {
+      container('helm') {
+        sh "helm upgrade --install --force --namespace=default --values=hmda-help/kubernetes/values.yaml --set image.tag=${gitBranch} hmda-help-${gitBranch} kubernetes/hmda-help"
+      }
+    }
+
+   }
+
+}

--- a/kubernetes/hmda-help/templates/service.yaml
+++ b/kubernetes/hmda-help/templates/service.yaml
@@ -29,9 +29,9 @@ metadata:
     getambassador.io/config: |
       apiVersion: ambassador/v0
       kind: Mapping
-      name: hmda_help_mapping
+      name: hmda_help_{{ .Values.image.tag }}_mapping
       prefix: /hmda-help-{{ .Values.image.tag }}/
-      rewrite: /hmda-help-{{ .Values.image.tag }}/
+      rewrite: /hmda-help/
       service: {{ include "hmda-help.fullname" . }}:{{ .Values.service.port }}
 spec:
   type: {{ .Values.ambassador.service.type }}

--- a/kubernetes/hmda-help/templates/service.yaml
+++ b/kubernetes/hmda-help/templates/service.yaml
@@ -30,8 +30,8 @@ metadata:
       apiVersion: ambassador/v0
       kind: Mapping
       name: hmda_help_mapping
-      prefix: /hmda-help/
-      rewrite: /hmda-help/
+      prefix: /hmda-help-{{ .Values.image.tag }}/
+      rewrite: /hmda-help-{{ .Values.image.tag }}/
       service: {{ include "hmda-help.fullname" . }}:{{ .Values.service.port }}
 spec:
   type: {{ .Values.ambassador.service.type }}

--- a/kubernetes/hmda-help/templates/service.yaml
+++ b/kubernetes/hmda-help/templates/service.yaml
@@ -29,8 +29,8 @@ metadata:
     getambassador.io/config: |
       apiVersion: ambassador/v0
       kind: Mapping
-      name: hmda_help_{{ .Values.image.tag }}_mapping
-      prefix: /hmda-help-{{ .Values.image.tag }}/
+      name: hmda_help_mapping
+      prefix: /hmda-help/
       rewrite: /hmda-help/
       service: {{ include "hmda-help.fullname" . }}:{{ .Values.service.port }}
 spec:


### PR DESCRIPTION
This PR adds a jenkinsfile to the hmda-help application to allow it to be deployed using a Jenkins multribranch CI/CD pipeline.

This PR also edits the helm chart to include the name (image tag) of the branch that is being built in the helm package name and the route for ambassador.

So a pod built and deployed using the master branch would be deployed as `hmda-help-master` and would use the route `hmda-help-master`.