### PR TITLE
hmdaFiler should default to false

### DIFF
--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -32,7 +32,9 @@ const nestStateForApi = state => {
     rssd: parseInt(state.rssd, 10) || -1,
     emailDomains: Array.isArray(state.emailDomains)
       ? state.emailDomains
-      : state.emailDomains ? [state.emailDomains] : [],
+      : state.emailDomains
+      ? [state.emailDomains]
+      : [],
     respondent: {
       name: state.respondentName || '',
       state: state.respondentState || '',
@@ -48,7 +50,7 @@ const nestStateForApi = state => {
       idRssd: parseInt(state.topHolderIdRssd, 10) || -1,
       name: state.topHolderName || ''
     },
-    hmdaFiler: true
+    hmdaFiler: false
   }
   return api
 }


### PR DESCRIPTION
### NOTE: this PR will have a back-end PR with it so that an update to an existing filer, who has already filed, doesn't reset this flag.

`hmdaFiler` should default to false as that flag is used to determine if a filer has filed, not if they should file.